### PR TITLE
add pages for index, edit, and create for organizations

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -19,6 +19,10 @@ import ArticleIndexPage from "main/pages/Article/ArticleIndexPage";
 import ArticleCreatePage from "main/pages/Article/ArticleCreatePage";
 import ArticleEditPage from "main/pages/Article/ArticleEditPage";
 
+import UCSBOrganizationIndexPage from "main/pages/UCSBOrganization/UCSBOrganizationIndexPage";
+import UCSBOrganizationCreatePage from "main/pages/UCSBOrganization/UCSBOrganizationCreatePage";
+import UCSBOrganizationEditPage from "main/pages/UCSBOrganization/UCSBOrganizationEditPage";
+
 import PlaceholderIndexPage from "main/pages/Placeholder/PlaceholderIndexPage";
 import PlaceholderCreatePage from "main/pages/Placeholder/PlaceholderCreatePage";
 import PlaceholderEditPage from "main/pages/Placeholder/PlaceholderEditPage";
@@ -190,6 +194,29 @@ function App() {
             exact
             path="/diningcommonsmenuitem/create"
             element={<UCSBDiningCommonsMenuItemCreatePage />}
+          />
+        </>
+      )}
+      {hasRole(currentUser, "ROLE_USER") && (
+        <>
+          <Route
+            exact
+            path="/ucsborganizations"
+            element={<UCSBOrganizationIndexPage />}
+          />
+        </>
+      )}
+      {hasRole(currentUser, "ROLE_ADMIN") && (
+        <>
+          <Route
+            exact
+            path="/ucsborganizations/edit/:orgCode"
+            element={<UCSBOrganizationEditPage />}
+          />
+          <Route
+            exact
+            path="/ucsborganizations/create"
+            element={<UCSBOrganizationCreatePage />}
           />
         </>
       )}

--- a/frontend/src/main/components/Nav/AppNavbar.jsx
+++ b/frontend/src/main/components/Nav/AppNavbar.jsx
@@ -80,6 +80,9 @@ export default function AppNavbar({
                   <Nav.Link as={Link} to="/diningcommonsmenuitem">
                     UCSBDiningCommonsMenuItem
                   </Nav.Link>
+                  <Nav.Link as={Link} to="/ucsborganizations">
+                    UCSBOrganizations
+                  </Nav.Link>
                   <Nav.Link as={Link} to="/helprequest">
                     Help Request
                   </Nav.Link>

--- a/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationCreatePage.jsx
+++ b/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationCreatePage.jsx
@@ -1,0 +1,12 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function UCSBOrganizationCreatePage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Create page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationEditPage.jsx
+++ b/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationEditPage.jsx
@@ -1,0 +1,12 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function UCSBOrganizationEditPage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Edit page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationIndexPage.jsx
+++ b/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationIndexPage.jsx
@@ -1,0 +1,18 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function UCSBOrganizationIndexPage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Index page not yet implemented</h1>
+        <p>
+          <a href="/ucsborganizations/create">Create</a>
+        </p>
+        <p>
+          <a href="/ucsborganizations/edit/1">Edit</a>
+        </p>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationCreatePage.test.jsx
+++ b/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationCreatePage.test.jsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import UCSBOrganizationCreatePage from "main/pages/UCSBOrganization/UCSBOrganizationCreatePage";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import { expect } from "vitest";
+
+describe("UCSBOrganizationCreatePage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    // arrange
+
+    setupUserOnly();
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+
+    await screen.findByText("Create page not yet implemented");
+    expect(
+      screen.getByText("Create page not yet implemented"),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationEditPage.test.jsx
+++ b/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationEditPage.test.jsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import UCSBOrganizationEditPage from "main/pages/UCSBOrganization/UCSBOrganizationEditPage";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import { expect } from "vitest";
+
+describe("UCSBOrganizationEditPage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    // arrange
+
+    setupUserOnly();
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationEditPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+    await screen.findByText("Edit page not yet implemented");
+    expect(
+      screen.getByText("Edit page not yet implemented"),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationIndexPage.test.jsx
+++ b/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationIndexPage.test.jsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import UCSBOrganizationIndexPage from "main/pages/UCSBOrganization/UCSBOrganizationIndexPage";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("UCSBOrganizationIndexPage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    // arrange
+
+    setupUserOnly();
+
+    // act
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("Index page not yet implemented");
+
+    // assert
+    expect(
+      screen.getByText("Index page not yet implemented"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Create")).toBeInTheDocument();
+    expect(screen.getByText("Edit")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #15.

Does not depend on other PRS to be merged first

In this PR, we add placeholder pages for index, create, and edit pages for the UCSBOrganization tables.

You can see on dokku instance:

https://team02-rushabhtaneja-dev.dokku-11.cs.ucsb.edu/ucsborganizations

# Screenshots

<img width="1570" height="488" alt="image" src="https://github.com/user-attachments/assets/17a15809-a48f-4d79-a00e-47e133c23838" />
