### PR TITLE
Add UCSBDiningCommonsMenuItem end-to-end test

### DIFF
--- a/src/test/java/edu/ucsb/cs156/example/web/UCSBDiningCommonsMenuItemWebIT.java
+++ b/src/test/java/edu/ucsb/cs156/example/web/UCSBDiningCommonsMenuItemWebIT.java
@@ -1,0 +1,66 @@
+package edu.ucsb.cs156.example.web;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
+import edu.ucsb.cs156.example.WebTestCase;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@ActiveProfiles("integration")
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
+public class UCSBDiningCommonsMenuItemWebIT extends WebTestCase {
+  @Test
+  public void admin_user_can_create_edit_delete_dining_commons_menu_item() throws Exception {
+    setupUser(true);
+
+    page.getByText("UCSBDiningCommonsMenuItem").click();
+
+    page.getByText("Create UCSBDiningCommonsMenuItem").click();
+    assertThat(page.getByText("Create New UCSBDiningCommonsMenuItem")).isVisible();
+    page.getByTestId("UCSBDiningCommonsMenuItemForm-diningCommonsCode").fill("ortega");
+    page.getByTestId("UCSBDiningCommonsMenuItemForm-name").fill("Chicken Tenders");
+    page.getByTestId("UCSBDiningCommonsMenuItemForm-station").fill("Entree");
+    page.getByTestId("UCSBDiningCommonsMenuItemForm-submit").click();
+
+    assertThat(page.getByTestId("UCSBDiningCommonsMenuItemTable-cell-row-0-col-name"))
+        .hasText("Chicken Tenders");
+    assertThat(page.getByTestId("UCSBDiningCommonsMenuItemTable-cell-row-0-col-station"))
+        .hasText("Entree");
+
+    page.getByTestId("UCSBDiningCommonsMenuItemTable-cell-row-0-col-Edit-button").click();
+    assertThat(page.getByText("Edit UCSBDiningCommonsMenuItem")).isVisible();
+    page.getByTestId("UCSBDiningCommonsMenuItemForm-name").fill("Pasta");
+    page.getByTestId("UCSBDiningCommonsMenuItemForm-station").fill("Main");
+    page.getByTestId("UCSBDiningCommonsMenuItemForm-submit").click();
+
+    assertThat(page.getByTestId("UCSBDiningCommonsMenuItemTable-cell-row-0-col-name"))
+        .hasText("Pasta");
+    assertThat(page.getByTestId("UCSBDiningCommonsMenuItemTable-cell-row-0-col-station"))
+        .hasText("Main");
+
+    page.getByTestId("UCSBDiningCommonsMenuItemTable-cell-row-0-col-Delete-button").click();
+
+    assertThat(page.getByTestId("UCSBDiningCommonsMenuItemTable-cell-row-0-col-name"))
+        .not()
+        .isVisible();
+  }
+
+  @Test
+  public void regular_user_cannot_create_dining_commons_menu_item() throws Exception {
+    setupUser(false);
+
+    page.getByText("UCSBDiningCommonsMenuItem").click();
+
+    assertThat(page.getByText("Create UCSBDiningCommonsMenuItem")).not().isVisible();
+    assertThat(page.getByTestId("UCSBDiningCommonsMenuItemTable-cell-row-0-col-name"))
+        .not()
+        .isVisible();
+  }
+}


### PR DESCRIPTION
Closes #117 

## Overview

This PR adds an end-to-end test for the `UCSBDiningCommonsMenuItem` frontend CRUD UI.

## Changes

- Added `UCSBDiningCommonsMenuItemWebIT`
- Tests that an admin user can create, edit, and delete a dining commons menu item through the UI
- Tests that a regular user cannot see the create button for dining commons menu items

## Validation

Ran:

```bash
INTEGRATION=true mvn test-compile failsafe:integration-test -Dit.test=UCSBDiningCommonsMenuItemWebIT